### PR TITLE
Updated Phantasma site and Github

### DIFF
--- a/WebSite/wwwroot/index.html
+++ b/WebSite/wwwroot/index.html
@@ -163,9 +163,9 @@
                 <small class="d-block mb-2">by <a href="https://github.com/Relfos" target="_blank">Relfos</a></small>
                 <p class="description">Phantasma is a platform where the users control their own content, instead of relying in third parties servers. The platform support any kind of transactions between users, eg: email, chat, files, money transfers. NEO was used for this project due to its fast transactions and C# support, combined with IPFS (a distributed file system) to store the actual messages, encrypted with the keys from the NEO wallets.</p>
                 <div class="link">
-                    <a href="http://45.76.88.140:7070/demo" target="_blank">Demo</a>
-                    <a href="http://45.76.88.140:7070/" target="_blank">Website</a>
-                    <a href="https://github.com/Relfos/phantasma" target="_blank">GitHub</a>
+                    <a href="https://phantasma.io/demo" target="_blank">Demo</a>
+                    <a href="https://phantasma.io/" target="_blank">Website</a>
+                    <a href="https://github.com/PhantasmaProtocol" target="_blank">GitHub</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Small change. Phantasma dApp was still using IP instead of URL.
Github was also updated.